### PR TITLE
dynamically check for mdadm arrays and print status for each of them

### DIFF
--- a/_lcd-functions.ksh
+++ b/_lcd-functions.ksh
@@ -132,7 +132,7 @@ fi
 
 if (( $(whereis mdadm | wc -w) != 1 ))
 then
-	MDADM_POOLS=$(ls /dev/md* | wc -w)
+	MDADM_POOLS=$(ls -1 /dev/md*  | egrep /dev/md'[0-9]+' | wc -l)
 	echo "Found $MDADM_POOLS mdadm pools !"
 fi
 
@@ -168,17 +168,20 @@ fi
 # get current index count as start value
 if (( $MDADM_POOLS > 0 ))
 then
-	INDEX=${#ROW[@]}
-	# query
-	MDADM_INFO=$(mdadm -D /dev/md0)
-	R_LEVEL=$(echo "$MDADM_INFO"| grep -o "raid[0-9].*")
-	R_STATE=$(echo "$MDADM_INFO"| grep -o "State :.*")
-	R_DEVICES=$(echo "$MDADM_INFO"| grep -o " /dev/s.*")
-	# result
-	ROW[${INDEX}]="MD0 : ${R_LEVEL}"
-	(( INDEX ++ ))
-	ROW[${INDEX}]="${R_STATE}"
-	(( INDEX ++ ))
+	for ARRAY in $(ls -1 /dev/md*  | egrep /dev/md'[0-9]+')
+	do
+		INDEX=${#ROW[@]}
+		# query
+		MDADM_INFO=$(mdadm -D $ARRAY)
+		R_LEVEL=$(echo "$MDADM_INFO"| grep -o "raid[0-9].*")
+		R_STATE=$(echo "$MDADM_INFO"| grep -o "State :.*")
+		R_DEVICES=$(echo "$MDADM_INFO"| grep -o " /dev/s.*")
+		# result
+		ROW[${INDEX}]="$(echo $ARRAY | cut -d "/" -f 3) : ${R_LEVEL}"
+		(( INDEX ++ ))
+		ROW[${INDEX}]="${R_STATE}"
+		(( INDEX ++ ))
+	done
 fi
 
 


### PR DESCRIPTION
Dear Justin Duplessis,

many thanks for your display script to utilize the Qnap NAS display. It works nicely on my TS-459.
Since I've a different mdadm raid setup with more than one array I extended the script to dynamically look for arrays, and print the status for each of them.

The output looks now as follows on my setup:
```
--------------------------------------------------------------
20161229 22:46:00   Info  => (re-)read input!
--------------------------------------------------------------
20161229 22:46:00   data-box         => 10.0.0.10
20161229 22:46:00   Ubuntu 16.04 LTS => 4.4.0-53-generic
20161229 22:46:00   /  ext4          => 2.7T  734G  74%
20161229 22:46:00   md2 : raid1      => State : clean 
20161229 22:46:00   md3 : raid5      => State : clean 
20161229 22:46:00   md4 : raid1      => State : clean 
20161229 22:46:00   Drive Temp       => MIN: 27 MAX: 34
20161229 22:46:00   Load Average     => 3.47 3.24 2.84
20161229 22:46:00   Uptime           => 1 day
20161229 22:46:00   Last Updated     => 22:46:00 12/29/16
--------------------------------------------------------------
20161229 22:47:01   Info  => lcd timeout, lights out!
--------------------------------------------------------------
```

Best regards,
Harald Gutmann
